### PR TITLE
Fix MoveToDownloadlist response parse error

### DIFF
--- a/src/My.JDownloader.Api/Namespaces/LinkgrabberV2.cs
+++ b/src/My.JDownloader.Api/Namespaces/LinkgrabberV2.cs
@@ -300,7 +300,7 @@ namespace My.JDownloader.Api.Namespaces
 
             var response =
                 ApiHandler.CallAction<object>(Device, "/linkgrabberv2/moveToDownloadlist", param,
-                    JDownloaderHandler.LoginObject);
+                    JDownloaderHandler.LoginObject, true);
             if (response == null)
                 return false;
             return true;


### PR DESCRIPTION
The response from "/linkgrabberv2/moveToDownloadlist" is encrypted. So, enabled decryption.